### PR TITLE
[MVC-988] Website Responsiveness: Text adaptation to resolution - final

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _site/
 .vscode-cache/
 .history
 .DS_Store
+.vscode
+vendor/bundle/ruby

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "terminal.integrated.fontFamily": "Hack Nerd Font"
+    "terminal.integrated.fontFamily": "Cascadia Code, monospace"
 }

--- a/_includes/2up.html
+++ b/_includes/2up.html
@@ -31,7 +31,7 @@
     {% endif %}
     {% if include.data %}
     <div class="inner-wrapper">
-      <div class="centred-data">
+      <div class="centered-data">
         <div class="t-data-wrapper">
           <h1 class="update-api partners"><span id="serviceUptake">0</span>%</h1>
           <h2>of our members enrolled in Kenya visited a provider in the month of July 2020</h2>

--- a/_includes/3upHorizontal.html
+++ b/_includes/3upHorizontal.html
@@ -63,7 +63,7 @@
     <div class="t-one {{include.colourTwo}} {{include.classList}} {% if include.flexList == 'reverse' %}left{% endif %} {% if include.flexList != 'reverse' %}right{% endif %}">
       {% if include.titleAlt %}
       {% if include.flexList == 'reverse' %}<div class="inner-wrapper">{% endif %}
-        <h1 class="section-title-centre">{{include.titleAlt}}</h1>
+        <h1 class="section-title-center">{{include.titleAlt}}</h1>
         {% if include.flexList == 'reverse' %}</div>{% endif %}
       {% endif %}
       {% if include.image %}

--- a/_sass/_blocks.scss
+++ b/_sass/_blocks.scss
@@ -309,7 +309,7 @@
     font-weight: 700;
   }
 
-  .section-title-centre {
+  .section-title-center {
     padding-top: spacing(1);
   }
 
@@ -350,6 +350,7 @@
       }
 
       h3 {
+        padding-top: 35px;
         width: 100%;
         font-size: map-get($font-scale, 4);
         line-height: 1;
@@ -584,7 +585,7 @@
 
 //classList
 
-.centred-data {
+.centered-data {
   @include mq($from: desktop) {
     position: absolute;
     top: 50%;
@@ -601,6 +602,7 @@
 
 .map {
   h2 {
+    padding-top: 35px;
     max-width: 620px;
 
     @include mq($until: tablet) {
@@ -962,6 +964,7 @@
   position: relative;
 
   h2 {
+    padding-bottom: 40px;
     width: 90%;
     text-align: center;
     margin-left: auto;
@@ -1209,8 +1212,10 @@
 
 .what-we-do {
   .center-container {
+    margin-top: 35px;
     position: relative;
     padding-top: 10px;
+    padding-bottom: 100px;
 
     @include mq($from: desktop) {
       position: absolute;
@@ -1221,6 +1226,7 @@
   }
   h2 {
     padding-left: 30px;
+    margin-top: 35px;
 
     .dot {
       width: 30px;
@@ -1272,6 +1278,7 @@
 
     @include mq($from: desktop) {
       flex-direction: row;
+      margin-top: 35px;
     }
 
     h3 {

--- a/_sass/_mq.scss
+++ b/_sass/_mq.scss
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-
+// More info on sass media queries see : https://sass-mq.github.io/sass-mq/#undefined-variable-mq-breakpoints
 // To enable support for browsers that do not support @media queries,
 // (IE <= 8, Firefox <= 3, Opera <= 9) set $mq-responsive to false
 // Create a separate stylesheet served exclusively to these browsers,


### PR DESCRIPTION
[MVC-988] Website Responsiveness: Text adaptation to resolution
Added margin-top and margin-bottom on text so that the Title doesnt move up to the photo as in the example given.
See Video:
https://user-images.githubusercontent.com/15178823/117426396-859cce00-af2c-11eb-9183-f386e9b3ccd7.mov
The fix is currently cosmetic because in working on this I discovered that:

wrapper divs have been used inside containers to wrap around more than one element. Convention dictates that container are used to contain more than one element and wrappers to wrap a single object to provide more functionality and interface to it.
the div class names are very confusing , for some elements it would help to give them ids just to make the code clearer and cleaner. I see this best tackled during the sprint on the architectural tech debt.

There was a mixup with the code initially pushed caused by changing laptops and not pulling and not confirming which branch I was on, while on the new machine. This I have since sorted and removed the previously added  "pragmatic-polic-change code."

[MVC-988]: https://triggerise.atlassian.net/browse/MVC-988