### PR TITLE
[MVC-1265] Join Us page - Wording doesn't fit in tiles

### DIFF
--- a/_includes/jobs.html
+++ b/_includes/jobs.html
@@ -10,7 +10,12 @@
                 <div class="flip-card-front">
                   <p>
                     <h3>{{job.['Job Title']}}</h3>
-                    <h3 class="location">{{job.Location}}</h3>
+                    {% assign location = job.Location%}
+                    {% if location == "Global" %}
+                      <h3 class="location">{{location}}</h3>
+                    {% elsif location != "Global"%}
+                      <h3 class="location">{{location | split: ", " | join:"<br />"}}</h3>
+                    {% endif %}
                   </p>
                 </div>
                 <div class="flip-card-back">
@@ -25,5 +30,3 @@
     </div>
   </div>
 </div>
-
-  

--- a/_includes/jobs.html
+++ b/_includes/jobs.html
@@ -11,11 +11,7 @@
                   <p>
                     <h3>{{job.['Job Title']}}</h3>
                     {% assign location = job.Location%}
-                    {% if location == "Global" %}
-                      <h3 class="location">{{location}}</h3>
-                    {% elsif location != "Global"%}
                       <h3 class="location">{{location | split: ", " | join:"<br />"}}</h3>
-                    {% endif %}
                   </p>
                 </div>
                 <div class="flip-card-back">


### PR DESCRIPTION
[MVC-1265] Join Us page - Wording doesn't fit in tiles:

Used Liquid If else statement to control text break for any text that is not "Global" to allow for break after comma. 

Error with tile location text: 
![Screenshot 2021-07-22 at 17 24 50](https://user-images.githubusercontent.com/15178823/126679167-08df69ba-4bbf-4bfb-a679-9fb76cd28fb9.png)

Fix:
![Screenshot 2021-07-22 at 17 24 22](https://user-images.githubusercontent.com/15178823/126679172-c5eafb45-fa5b-4019-b541-cc6c479e8a23.png)


[MVC-1265]: https://triggerise.atlassian.net/browse/MVC-1265