### PR TITLE
[MVC-1262] Join Us Page - Text is not adapting to Ipad Resolution

### DIFF
--- a/_sass/_blocks.scss
+++ b/_sass/_blocks.scss
@@ -1271,24 +1271,28 @@ blockquote {
     font-size: 60%;
   }
   @include mq(768px) {
-  padding-top: 10px;
-  font-size: 40%;
+    padding-top: 10px;
+    font-size: 40%;
   }
+  @include mq(1024px) {
+    padding-top: 10px;
+    font-size: 58%;
+    }
   @include mq(1280px) {
-  padding-top: 20px;
-  font-size: 80%;
+    padding-top: 20px;
+    font-size: 80%;
   }
   @include mq(1366px) {
-  padding-top: 25px;
-  font-size: 85%;
+    padding-top: 25px;
+    font-size: 85%;
   }
   @include mq(1440px) {
-  padding-top: 30px;
-  font-size: 90%;
+    padding-top: 30px;
+    font-size: 90%;
   }
   @include mq(1920px) {
-  padding-top: 30px;
-  font-size: 120%;
+    padding-top: 30px;
+    font-size: 120%;
   }
 }
   
@@ -1324,6 +1328,11 @@ blockquote:before {
     left: 50px;
     top: 40px;
   }
+  @include mq(1024px) {
+    font-size: 100%;
+    left: 65px;
+    top: 35px;
+  }
   @include mq(1280px) {
     font-size: 110%;
     left: 75px;
@@ -1346,14 +1355,13 @@ blockquote:before {
   }
 }
 
-blockquote:after { 
+blockquote:after {
   content: close-quote;
   display: block;
   font-weight: bold;
   font-size: 45px;
   color:  #1D214F;
   position: relative;
-  
     @include mq(360px) {
       font-size: 95%;
       left: 35px;
@@ -1375,6 +1383,11 @@ blockquote:after {
     @include mq(768px) {
       left: 55px;
       bottom: 24px;
+    }
+    @include mq(1024px) {
+      font-size: 100%;
+      left: 135px;
+      bottom: 28px;
     }
     @include mq(1280px) {
       font-size: 110%;


### PR DESCRIPTION
[MVC-1262] Join Us Page - Text is not adapting to ipad Resolution

 - Added include media query code for 1024px x 768px (ipad res) in _blocks.scss for format join us quote text. 
 
Fix Screenshot: 
<img width="1021" alt="Screenshot 2021-07-22 at 21 16 20" src="https://user-images.githubusercontent.com/15178823/126689559-6a2475f7-f9a6-4d7f-b50d-182a1d63e064.png">





[MVC-1262]: https://triggerise.atlassian.net/browse/MVC-1262