### PR TITLE
[MVC-1288 ] Missing text on Cookies page

### DIFF
--- a/_includes/contactPolicyBanner.html
+++ b/_includes/contactPolicyBanner.html
@@ -9,5 +9,11 @@
         {{include.description | markdownify}}
       </div>
     {% endif %}
+
+    <div class="cookies-banner">
+      {% if page.title == "Cookies" %}
+        <p>{{ include.description }}</p>
+      {% endif %}
+    </div>
   </div>
 </div>

--- a/cookies.markdown
+++ b/cookies.markdown
@@ -1,7 +1,7 @@
 ---
 title: Cookies
 date: 2020-07-28 11:50:00 Z
-Body: |-
+description: |-
   We use cookies to improve our website. By continuing to use this website, you consent to the placement of these cookies on your device. We are committed to the lawful and transparent collection and use of personal data.
 
   **What is a Cookie?**


### PR DESCRIPTION
[MVC-1288 ] Missing text on Cookies page
- Fixed missing cookies text by adding cookies.description on contactPolicyBanner.html

Before Fix 
<img width="1402" alt="Screenshot 2021-07-27 at 12 15 43" src="https://user-images.githubusercontent.com/15178823/127150969-725a1806-724c-4809-ab09-f7abd6f76ff0.png">


After Fix 
<img width="1427" alt="Screenshot 2021-07-27 at 14 59 08" src="https://user-images.githubusercontent.com/15178823/127150992-c2093ab9-4193-4f34-ac0d-2161bbc57b43.png">
