### PR TITLE
[MVC-1266] - Homepage - wording cut off

### DIFF
--- a/_sass/_blocks.scss
+++ b/_sass/_blocks.scss
@@ -29,7 +29,9 @@
 
 .section:not(.carousel) {
   height: auto !important;
+  display: contents;
 }
+
 .fp-tableCell {
   height: auto !important;
 }


### PR DESCRIPTION
[MVC-1266] - Homepage - wording cut off

 - Added display:contents on.section div in _blocks.scss file to show all content on homepage irrespective of screen type.

[MVC-1266]: https://triggerise.atlassian.net/browse/MVC-1266