### PR TITLE
[OFE-85]Cookies-Banner-Link-Read-More

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,7 +27,7 @@
 </footer>
 <div class="cookies-banner">
   <div class="wrapper">
-    <p>We use cookies to understand how you use our website and improve your experience. <a href="">Read more about this.</a> <span class="cookies-button">Okay, I accept</span></p>
+    <p>We use cookies to understand how you use our website and improve your experience. <a href="https://triggerise.org/cookies/">Read more about this.</a> <span class="cookies-button">Okay, I accept</span></p>
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/countup@1.8.2/dist/countUp.min.js" type="text/javascript"></script>


### PR DESCRIPTION
[OFE-85]Cookies-Banner-Link-Read-More

 - Added correct cookies link to read more button on cookies banners.

Video of Fix: 
https://user-images.githubusercontent.com/15178823/133122236-4c28ce5b-7e6c-4a4f-b2a0-2a4d95264d8d.mov



[OFE-85]: https://triggerise.atlassian.net/browse/OFE-85